### PR TITLE
fix: wrong config routes

### DIFF
--- a/packages/dapp/src/Routes.jsx
+++ b/packages/dapp/src/Routes.jsx
@@ -10,13 +10,12 @@ import { Home } from './pages/Home';
 export const Routes = () => (
   <Switch>
     <Route exact path="/about" component={About} />
-    <Route>
+    <Route exact path={['/bridge', '/history', '/create']}>
       <Switch>
         <Layout>
           <Route exact path="/bridge" component={Home} />
           <Route exact path="/history" component={History} />
           <Route exact path="/create" component={CreateNFT} />
-          <Redirect to="/bridge" />
         </Layout>
       </Switch>
     </Route>


### PR DESCRIPTION
## Before:
- click icon should go to `/bridge` route
- `/create` should not redirect to `/bridge` page

https://user-images.githubusercontent.com/100658449/227448527-76b31b3f-e7a6-4673-bef6-0aad13d45dc6.mov

## After:

https://user-images.githubusercontent.com/100658449/227449441-279a962d-3ccc-4cd8-9ca0-02af367a8d2b.mov

Occur related to: #52 


